### PR TITLE
Recover the mic when the audio device changes mid-session

### DIFF
--- a/backtalk/ears.py
+++ b/backtalk/ears.py
@@ -97,8 +97,7 @@ class Ears:
         in_utterance = False
         elapsed = 0.0
 
-        with sd.InputStream(samplerate=RATE, channels=1, dtype="int16",
-                            blocksize=FRAME_LEN) as stream:
+        with _input_stream() as stream:
             while True:
                 block, _ = stream.read(FRAME_LEN)
                 elapsed += FRAME_MS / 1000
@@ -140,13 +139,36 @@ class Ears:
                         return transcribe(np.concatenate(frames))
 
 
+def _input_stream() -> sd.InputStream:
+    """Open the mic, surviving a device switch mid-session.
+
+    Field-caught: PortAudio caches the device list when it initializes,
+    and a Bluetooth headset flipping between listen and mic modes
+    (AirPods do this every time the mic opens) invalidates the cached
+    device. Every capture after that dies with -9986 until the process
+    restarts, so the voice line looks alive and never hears another
+    word. Re-initializing refreshes the list; one retry recovers.
+    """
+    opts = dict(samplerate=RATE, channels=1, dtype="int16",
+                blocksize=FRAME_LEN)
+    try:
+        return sd.InputStream(**opts)
+    except sd.PortAudioError:
+        print("[ears] audio device changed — reopening the mic", flush=True)
+        try:
+            sd._terminate()
+        except sd.PortAudioError:
+            pass  # already torn down; re-initializing is the part that counts
+        sd._initialize()
+        return sd.InputStream(**opts)
+
+
 def record_held(is_held, max_s: float = 60.0, min_s: float = 0.25) -> str | None:
     """Hold-to-talk capture: record raw audio while is_held() is True,
     then transcribe. The button is the VAD — no endpointing. Returns
     None for taps shorter than min_s (accidental presses)."""
     frames: list[np.ndarray] = []
-    with sd.InputStream(samplerate=RATE, channels=1, dtype="int16",
-                        blocksize=FRAME_LEN) as stream:
+    with _input_stream() as stream:
         while is_held() and len(frames) * FRAME_MS / 1000 < max_s:
             block, _ = stream.read(FRAME_LEN)
             frames.append(block[:, 0].copy())


### PR DESCRIPTION
## The bug

On macOS with Bluetooth headphones (AirPods Max here), the voice line transcribes
fine for the first several turns, then every recording after that fails:

```
||PaMacCore (AUHAL)|| Error on line 1322: err='-10851', msg=Audio Unit: Invalid Property Value
[ears] record/transcribe failed: PortAudioError('Error opening InputStream: Internal PortAudio error', -9986)
[ptt] (tap or empty — ignored)
```

Once it starts, it never recovers — every subsequent press fails the same way until
the process is restarted.

## Why

PortAudio caches the device list when it initializes. A Bluetooth headset flips
between listen mode and mic mode every time the mic opens, which invalidates the
cached device. `record_held` opens a fresh `InputStream` per press, so every open
after the switch hits a device that no longer exists as PortAudio remembers it.

The failure mode is quiet in the worst way: the voice line stays up, the greeting
plays, the key registers, `[ptt] recording` still prints — and the agent answers
"my ears hit an error" on every single press. Everything looks healthy.

## The fix

`_input_stream()` re-initializes PortAudio (which refreshes the device list) and
retries once on `PortAudioError`. Both capture paths use it — `record_held` for
push-to-talk and `Ears.listen_once` for the open mic.

The `_terminate()` call is guarded: it raises `PortAudioError` if PortAudio is
already down, which would otherwise turn the recovery path into a second crash.
(Found that one by testing the recovery, not by reading it.)

## Testing

On macOS 15 (darwin 25.6.0), Python 3.12, sounddevice 0.5.6:

- Normal open: unchanged.
- Simulated device invalidation (`sd._terminate()` to reproduce the -9986 state),
  then `_input_stream()` — recovers, logs `[ears] audio device changed — reopening the mic`.
- Full `record_held()` through a deliberately broken device — recovers and returns
  transcribed text.
- Live push-to-talk after the patch on the machine that produced the original logs.

Found while setting up fullstack-agent. Happy to adjust the approach if you'd
rather handle it at a different layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)