### PR TITLE
WSL2 self-heal: symlink the pulse socket WSLg actually creates

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -20,6 +20,16 @@
 # Terminal-invoked (inherits the terminal's mic permission). Ctrl-C hangs up.
 cd "$(dirname "$0")"
 export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+# WSL2 self-heal: PortAudio's ALSA pulse plugin looks for the socket at
+# the standard XDG runtime path regardless of $PULSE_SERVER, but WSLg
+# only creates it at /mnt/wslg/PulseServer. Without this symlink, audio
+# playback crashes the process outright ("terminate called ... dumped
+# core") instead of failing cleanly. This tmpfs dir resets every reboot,
+# so re-link it here on every launch rather than once.
+if [ -S /mnt/wslg/PulseServer ] && [ ! -S "/run/user/$(id -u)/pulse/native" ]; then
+  mkdir -p "/run/user/$(id -u)/pulse"
+  ln -sf /mnt/wslg/PulseServer "/run/user/$(id -u)/pulse/native"
+fi
 # Single-instance guard: a stale voice session left in a background
 # terminal answers the same mic alongside a fresh launch = two voices at
 # once, and it sounds haunted. One body, one mouth.


### PR DESCRIPTION
## Summary
- PortAudio's ALSA pulse plugin looks for the socket at the standard XDG runtime path regardless of `$PULSE_SERVER`, but WSLg only creates one at `/mnt/wslg/PulseServer`. Without a symlink, audio playback crashes the process outright ("terminate called ... dumped core") instead of failing cleanly.
- `run.sh` now re-links `/run/user/$UID/pulse/native` to `/mnt/wslg/PulseServer` on every launch (the tmpfs runtime dir resets each reboot), only when needed.

## Test plan
- [x] `bash -n run.sh` passes
- [x] Simulated the broken state (removed the `native` symlink) and confirmed the heal snippet recreates it correctly
- [x] With the healed symlink in place, verified `sounddevice` (used by `mouth.py`/`ears.py`) can query devices and play a tone with no crash
- [x] Confirmed no-op on setups where WSLg already provisions a working symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QgYjuW3CoTZVuvJPo1eBk