### PR TITLE
mouth: sweep orphaned espeak temp dirs at startup

### DIFF
--- a/backtalk/mouth.py
+++ b/backtalk/mouth.py
@@ -42,7 +42,9 @@ slow-motion garble.
 import os
 import queue
 import re
+import shutil
 import sys
+import tempfile
 import threading
 
 import numpy as np
@@ -80,6 +82,79 @@ def _ensure_espeak():
             break
 
 
+# Every espeak library filename phonemizer might copy, across platforms.
+# A directory holding exactly one of these and nothing else is a
+# phonemizer scratch dir and nobody else's.
+_ESPEAK_LIB_NAMES = (
+    "espeak-ng.dll",
+    "libespeak-ng.dll",
+    "libespeak-ng.so",
+    "libespeak-ng.so.1",
+    "libespeak-ng.dylib",
+)
+
+
+def _is_orphan_espeak_tempdir(path: str) -> bool:
+    """True only for a directory whose entire contents are a single espeak
+    shared library. phonemizer's scratch dirs look exactly like this and
+    nothing else on the system does, so this is the check that makes the
+    sweep safe to point at the shared temp directory."""
+    try:
+        entries = os.listdir(path)
+    except OSError:
+        return False
+    return len(entries) == 1 and entries[0] in _ESPEAK_LIB_NAMES
+
+
+def _sweep_orphan_espeak_tempdirs():
+    """Delete espeak scratch dirs left behind by previous runs.
+
+    phonemizer copies the espeak shared library into a fresh mkdtemp() for
+    every backend it builds, because espeak-ng keeps its state in globals
+    and dlopen refuses to load the same file twice (see the comment in
+    phonemizer/backend/espeak/api.py). Kokoro builds several backends, so
+    one voice line start leaves several of these behind.
+
+    On POSIX that cleanup rides on weakref.finalize and happens promptly.
+    On Windows phonemizer can only register it with atexit, and atexit does
+    not run when a process is *killed* rather than exited. Anything that
+    launches backtalk from a wrapper and stops it by terminating the process
+    — a launcher script, a service wrapper, a supervisor — therefore leaks
+    every directory it ever created. Sixty had accumulated on the machine
+    where this was found; the count grows per backend per start and never
+    falls.
+
+    Patching phonemizer in site-packages is not a fix, because an install
+    step that runs `uv sync` or `pip install -U` on launch overwrites it.
+    Sweeping at our own startup bounds the total at one run's worth instead.
+
+    Safety rests on two things, not on guesswork:
+      1. we only touch directories whose sole content is an espeak library;
+      2. Windows refuses to delete a DLL that is currently loaded, so a
+         concurrently running instance's directory fails the rmtree and is
+         left alone. The OS enforces that, we don't have to detect it.
+    """
+    root = tempfile.gettempdir()
+    swept = 0
+    try:
+        names = os.listdir(root)
+    except OSError:
+        return
+    for name in names:
+        path = os.path.join(root, name)
+        if not os.path.isdir(path) or not _is_orphan_espeak_tempdir(path):
+            continue
+        try:
+            shutil.rmtree(path)
+            swept += 1
+        except OSError:
+            # In use by a live espeak, or not ours to delete. Either way,
+            # leaving it is correct — the next start will get it.
+            pass
+    if swept:
+        log(f"[mouth] swept {swept} orphaned espeak temp dir(s)")
+
+
 def warm():
     """Load the Kokoro pipeline (first call downloads the model to the
     HF cache). Called at startup while the greeting text is composed."""
@@ -87,6 +162,9 @@ def warm():
     with _pipe_lock:
         if _pipe is None:
             _ensure_espeak()
+            # Before kokoro creates this run's scratch dirs, clear out the
+            # ones previous runs could not clean up on their way out.
+            _sweep_orphan_espeak_tempdirs()
             from kokoro import KPipeline
             # The voice name's first letter IS the language pipeline:
             # a=American English, b=British English, e/f/h/i/j/p/z = the


### PR DESCRIPTION
# Sweep orphaned espeak temp dirs at startup

## The problem

`phonemizer` copies the espeak shared library into a fresh `mkdtemp()` for every
backend it builds — espeak-ng keeps its state in globals, and `dlopen` won't load
the same file twice. Kokoro builds several backends, so one `warm()` leaves
several of these directories behind.

Cleanup is registered two different ways, and only one of them works reliably.
From `phonemizer/backend/espeak/api.py`:

```python
# But... weakref implementation does not work on windows so we register
# the cleanup with atexit. This means that, on Windows, all the
# temporary directories created by EspeakAPI instances will remain on
# disk until the Python process exit.
if sys.platform == 'win32':
    atexit.register(self._delete_win32)
else:
    weakref.finalize(self, self._delete, self._library, self._tempdir)
```

`atexit` does not run when a process is **killed** rather than exited. Anything
that launches backtalk from a wrapper and stops it by terminating the process — a
launcher script, a service wrapper, a supervisor, a stop button that calls
`taskkill` — leaks every directory it ever created.

This is not hypothetical: **60 orphaned directories** had accumulated on the
machine where I found it. The count grows by one per backend per start and never
falls. Each holds a ~410 KB copy of `espeak-ng.dll`.

## Why not fix it in phonemizer

Two reasons:

1. It's arguably not phonemizer's bug — its comment is accurate about what it
   can guarantee, and `atexit` genuinely cannot cover `SIGKILL`-equivalent
   termination.
2. Even as a local workaround it doesn't survive: any install step that runs
   `uv sync` or `pip install -U` on launch overwrites `site-packages`.

Sweeping at backtalk's own startup bounds the total at one run's worth,
regardless of how the previous run ended.

## The change

One function, called from `warm()` immediately before Kokoro creates this run's
directories. 78 lines added, nothing modified or removed.

## Why it's safe to point at the shared temp directory

Two independent guarantees, neither of them a heuristic:

1. **Shape check** — only a directory whose *sole* entry is an espeak shared
   library is removed. phonemizer's scratch dirs look exactly like that, and
   nothing else in a temp directory does.
2. **The OS enforces the rest** — Windows refuses to delete a loaded DLL, so a
   concurrently running instance's directory fails the `rmtree` and is skipped.
   The code doesn't have to detect concurrent instances; it cannot win that race
   because the filesystem won't let it.

`shutil.rmtree` failures are caught and ignored: a directory still in use is left
for the next start, which is the correct outcome.

## Testing

Run against a **live instance** with four in-use directories present:

```
synthetic orphans removed : 3/3     <- want 3
decoy (multi-file) kept   : True    <- want True
decoy (non-espeak) kept   : True    <- want True
decoy (empty dir) kept    : True    <- want True
LIVE voice-line dirs kept : 4/4     <- want all (DLL is loaded)
```

The last line is the one that matters: the sweep ran with four in-use
directories sitting in the same temp folder and left every one alone.

Confirmed in production across three restarts — the log line appears, the count
returns to one run's worth each time instead of climbing:

```
11:45:11 [mouth] swept 4 orphaned espeak temp dir(s)
12:00:20 [mouth] swept 4 orphaned espeak temp dir(s)
```

## Notes

- Windows is where the leak is unbounded, but the sweep is platform-neutral and
  harmless on POSIX, where `weakref.finalize` already keeps the count near zero.
- It logs only when it actually removes something, so a clean system stays quiet.
- No new dependencies; `shutil` and `tempfile` are stdlib.
