### PR TITLE
Add Fish Audio as a third voice engine (cloned voices, streams PCM, no ffmpeg)

### DIFF
--- a/backtalk/config.py
+++ b/backtalk/config.py
@@ -160,6 +160,36 @@ DEFAULTS = {
                    "acompressor=threshold=-18dB:ratio=2.5:attack=8:"
                    "release=120:makeup=4dB,alimiter=limit=0.95"),
     },
+    # Optional premium voice: Fish Audio on YOUR key — including a voice
+    # you cloned yourself on fish.audio (reference_id below is your
+    # model's id). Streams raw PCM, so unlike ElevenLabs it needs NO
+    # ffmpeg. The key NEVER goes in a file: it's read from the macOS
+    # Keychain (item `backtalk-fish`) or Linux secret-tool, with the
+    # FISH_AUDIO_API_KEY env var as last-resort fallback — see
+    # mouth._get_fish_key for the seeding one-liners. Kokoro remains the
+    # automatic fallback, so the voice degrades instead of going mute if
+    # the cloud fails. If both fish and elevenlabs are enabled, fish
+    # answers first.
+    "fish": {
+        "enabled": False,
+        # Your voice model's id on fish.audio. Every account can clone a
+        # voice there; this is how your clone gets wired in.
+        "reference_id": "",
+        # Purely for you. Model ids are unreadable six months later, so put
+        # the human name here; nothing reads it.
+        "voice_note": "",
+        # The TTS generation, sent as the request's `model` header:
+        # "s2.1-pro-free" is the free tier and works on an unfunded
+        # account; "s1", "s2-pro", and "s2.1-pro" are paid and return
+        # 402 Payment Required until the account holds credits.
+        "model": "s2.1-pro-free",
+        # Which OS credential-store entry holds the key. Change it if you
+        # already keep a Fish Audio key under a name of your own.
+        "key_slot": "backtalk-fish",
+        # "low", "balanced", or "normal" — Fish Audio's own latency knob.
+        "latency": "balanced",
+        "sample_rate": 44100,
+    },
     # Where the signal-bus files are written (.voice_state,
     # .voice_waveform, .voice_loading_pid) — anything can watch them;
     # visualizers pair with this contract. Default: the repo root.

--- a/backtalk/mouth.py
+++ b/backtalk/mouth.py
@@ -184,6 +184,95 @@ def _stream_elevenlabs(text: str, timeout: float):
         raise feed_error[0]
 
 
+def _fish_cfg() -> dict:
+    """The "fish" block (Fish Audio engine). Read with .get so a config
+    written before this engine existed keeps working unchanged."""
+    return CFG.get("fish") or {}
+
+
+_fish_key_cache: str | None = None
+
+
+def _fish_key_slot() -> str:
+    """The credential-store entry name, so someone who already keeps a
+    key under their own name points at it instead of storing a second
+    copy."""
+    return str(_fish_cfg().get("key_slot") or "backtalk-fish")
+
+
+def _get_fish_key() -> str:
+    """The Fish Audio API key, from the most secure store available —
+    NEVER from a file in this repo. Same lookup order as ElevenLabs:
+      1. macOS Keychain, item `backtalk-fish` by default (change it with
+         fish.key_slot) — seed it once with:
+         security add-generic-password -a "$USER" -s backtalk-fish -T /usr/bin/security -w
+      2. Linux secret-tool (libsecret):
+         secret-tool store --label backtalk service backtalk-fish
+      3. the FISH_AUDIO_API_KEY environment variable — the last-resort
+         fallback, and the only option on Windows for now."""
+    global _fish_key_cache
+    if _fish_key_cache is not None:
+        return _fish_key_cache
+    import subprocess
+    key = ""
+    try:
+        if sys.platform == "darwin":
+            r = subprocess.run(["security", "find-generic-password",
+                                "-s", _fish_key_slot(), "-w"],
+                               capture_output=True, text=True, timeout=5)
+            if r.returncode == 0:
+                key = r.stdout.strip()
+        elif sys.platform.startswith("linux"):
+            from shutil import which
+            if which("secret-tool"):
+                r = subprocess.run(["secret-tool", "lookup", "service",
+                                    _fish_key_slot()],
+                                   capture_output=True, text=True, timeout=5)
+                if r.returncode == 0:
+                    key = r.stdout.strip()
+    except Exception:
+        pass
+    _fish_key_cache = key or os.environ.get("FISH_AUDIO_API_KEY", "")
+    return _fish_key_cache
+
+
+def _fish_ready() -> bool:
+    f = _fish_cfg()
+    return bool(f.get("enabled") and f.get("reference_id")
+                and _get_fish_key())
+
+
+def _stream_fish(text: str, timeout: float):
+    """Fish Audio -> raw PCM stream -> int16 chunks. No ffmpeg needed:
+    format "pcm" streams 16-bit mono at the requested sample_rate, so
+    bytes go from the wire to the speaker path directly. The `model`
+    header picks the TTS generation (s1 default); `reference_id` is the
+    user's own cloned voice."""
+    import httpx
+
+    f = _fish_cfg()
+    rate = int(f.get("sample_rate") or 44100)
+    carry = b""
+    with httpx.stream(
+            "POST", "https://api.fish.audio/v1/tts",
+            headers={"Authorization": f"Bearer {_get_fish_key()}",
+                     "model": str(f.get("model") or "s1"),
+                     "Content-Type": "application/json"},
+            json={"text": text,
+                  "reference_id": f["reference_id"],
+                  "format": "pcm",
+                  "sample_rate": rate,
+                  "latency": str(f.get("latency") or "balanced")},
+            timeout=timeout) as r:
+        r.raise_for_status()
+        for chunk in r.iter_bytes(chunk_size=4096):
+            data = carry + chunk
+            usable = len(data) - (len(data) % 2)
+            carry = data[usable:]
+            if usable:
+                yield rate, np.frombuffer(data[:usable], dtype=np.int16)
+
+
 _el_key_cache: str | None = None
 
 
@@ -241,8 +330,17 @@ def _elevenlabs_ready() -> bool:
 
 def synth_stream(text: str, timeout: float = 30.0):
     """One sentence -> yields (sample_rate, pcm_chunk) as the TTS
-    renders. ElevenLabs when configured, Kokoro otherwise — and Kokoro
-    as the fallback on ANY ElevenLabs failure. Degrade, never mute."""
+    renders. Fish Audio or ElevenLabs when configured, Kokoro otherwise —
+    and Kokoro as the fallback on ANY cloud failure. Degrade, never
+    mute."""
+    if _fish_ready():
+        try:
+            for rate, pcm in _stream_fish(text, timeout):
+                yield rate, pcm
+            return
+        except Exception as e:
+            log(f"[mouth] fish audio failed ({str(e)[:60]}) — "
+                f"falling back to {CFG['voice']}")
     if _elevenlabs_ready():
         try:
             for pcm in _stream_elevenlabs(text, timeout):

--- a/backtalk/mouth.py
+++ b/backtalk/mouth.py
@@ -242,18 +242,32 @@ def _fish_ready() -> bool:
                 and _get_fish_key())
 
 
+_fish_http = None
+
+
+def _get_fish_http():
+    """One keep-alive connection to Fish Audio for the life of the
+    process. A fresh client per sentence pays a TLS handshake inside the
+    gap between spoken sentences; reuse shaves ~0.2-0.4s off each.
+    httpx.Client is thread-safe, and the mouth synthesizes from a single
+    worker thread anyway."""
+    global _fish_http
+    if _fish_http is None:
+        import httpx
+        _fish_http = httpx.Client()
+    return _fish_http
+
+
 def _stream_fish(text: str, timeout: float):
     """Fish Audio -> raw PCM stream -> int16 chunks. No ffmpeg needed:
     format "pcm" streams 16-bit mono at the requested sample_rate, so
     bytes go from the wire to the speaker path directly. The `model`
     header picks the TTS generation (s1 default); `reference_id` is the
     user's own cloned voice."""
-    import httpx
-
     f = _fish_cfg()
     rate = int(f.get("sample_rate") or 44100)
     carry = b""
-    with httpx.stream(
+    with _get_fish_http().stream(
             "POST", "https://api.fish.audio/v1/tts",
             headers={"Authorization": f"Bearer {_get_fish_key()}",
                      "model": str(f.get("model") or "s1"),


### PR DESCRIPTION
## What this adds

**Fish Audio (fish.audio) as a third voice engine**, beside Kokoro and ElevenLabs. The draw: Fish Audio lets anyone clone **their own voice** (or build a character voice) in their account and drive it by API — so an agent can literally speak in the voice its person made for it. Engine order when enabled: fish → elevenlabs → Kokoro.

## Why it fits this codebase

- **Degrade, never mute** — the fish path is wrapped in the exact same try/fallback shape as ElevenLabs; any cloud failure logs one line and falls back to the configured Kokoro voice.
- **No new dependencies.** Fish Audio streams `format: "pcm"` (16-bit mono at the configured `sample_rate`), so chunks go from `httpx.stream` straight into the existing playback path. Unlike the ElevenLabs route there is **no ffmpeg** involved. Uses only `httpx` + `numpy`, both already in the tree.
- **Key handling mirrors `_get_elevenlabs_key`** — macOS Keychain (item `backtalk-fish`, renameable via `fish.key_slot`), Linux secret-tool, `FISH_AUDIO_API_KEY` env var as the Windows last resort. Never in a file.
- **Backwards compatible** — `mouth` reads the block with `.get`, so a `backtalk.json` written before this engine existed keeps working unchanged; the `fish` block ships disabled in DEFAULTS.

## Config

```json
"fish": {
  "enabled": true,
  "reference_id": "<your voice model id on fish.audio>",
  "model": "s2.1-pro-free"
}
```

The default model is `s2.1-pro-free` deliberately: it works on an unfunded account. The paid tiers (`s1`, `s2-pro`, `s2.1-pro`) return **402 Payment Required** until the account holds credits — the DEFAULTS comment says so explicitly, so nobody debugs a 402 blind. The person's `reference_id` is listable via `GET https://api.fish.audio/model?self=true`.

## Tested

Windows 11, real account, real cloned voice: config parses, sentences stream and play through the long-lived output stream (audio laws respected — the engine only feeds PCM into the existing `_play_stream` path), interrupt behavior unchanged, and the Kokoro fallback fires correctly on both a missing key and an unfunded model tier (402). macOS/Linux keychain lookups follow the ElevenLabs code path verbatim but I could only exercise the env-var branch — worth one audition on a Mac before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
